### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This pipeline is designed to be executed on Unix-based systems. Most of the code
 
 4. Via [dbGAP](http://www.ncbi.nlm.nih.gov/gap), obtain access to the raw TCGA data. Then obtain a private key that allows you download raw data via the [Cancer Genomics Hub](https://cghub.ucsc.edu/access/get_access.html). Store this key file as ```cghub.key``` in the current directory.
 
-5. In the ```Genome``` directory, store the reference genome file and GTF file that can be obtained from [here](http://support.illumina.com/sequencing/sequencing_software/igenome.html). We used version hg19. After extracting these files, you will find the reference genome in Homo_sapiens/UCSC/hg19/Sequence/WholeGenomeFasta/genome.fa and the GTF file in Homo_sapiens/UCSC/hg19/Annotation/Genes/genes.gtf. Move these directly to the local Genome directory.
+5. In the ```Genome``` directory, store the reference genome file and GTF file that can be obtained from [here](http://support.illumina.com/sequencing/sequencing_software/igenome.html). We used version hg19. After extracting these files, you will find the reference genome in Homo_sapiens/UCSC/hg19/Sequence/WholeGenomeFasta/genome.fa and the GTF file in Homo_sapiens/UCSC/hg19/Annotation/Archives/archive-2012-03-09-03-24-41/Genes/genes.gtf. Move these directly to the local Genome directory.
 
 6. Execute Scripts/process_tcga_rsubread at the command line to begin downloading and normalizing samples.
 


### PR DESCRIPTION
You may be interested in a minor update to the README of your otherwise excellent dataset:

I added archival link to the presumably correct annotation file containing 23368 gene annotations as mentioned in the original paper.

This may make things easier to reproduce. From the gene count of the archived annotations, 2012 is the only version, which matches the reported number of gene ids:

archive-2010-09-27-22-25-17 22143
archive-2011-01-27-18-25-49 22335
archive-2011-08-30-21-45-18 23228
archive-2012-03-09-03-24-41 23368
archive-2014-06-02-13-47-56 25370
archive-2015-07-17-14-32-32 26364
